### PR TITLE
Run extra squeaknode instance in docker-compose

### DIFF
--- a/docker/config.ini
+++ b/docker/config.ini
@@ -1,3 +1,6 @@
+[node]
+network=testnet
+
 [lnd]
 host=lnd
 tls_cert_path=~/.lnd/tls.cert
@@ -8,6 +11,7 @@ rpc_host=bitcoin-core
 rpc_port=18332
 rpc_user=devuser
 rpc_pass=devpass
+zeromq_hashblock_port=28334
 
 [webadmin]
 enabled=true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,3 +35,27 @@ services:
     container_name: tor-socks-proxy
     image: peterdavehello/tor-socks-proxy:latest
     restart: unless-stopped
+
+  squeaknode:
+    image: squeaknode
+    build:
+      context: ../
+      dockerfile: Dockerfile
+    volumes:
+      - ~/.lnd:/root/.lnd
+      - ./config.ini:/config.ini
+    ports:
+      - 12995:12994
+      - 8557:8555
+      - 18557:18555
+    links:
+      - "bitcoin-core:bitcoin-core"
+      - "lnd:lnd"
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+    entrypoint: ["./start-squeaknode.sh"]
+
+volumes:
+  # lnd is needed for sharing tht tls certificate
+  test_lnd_client_dir:
+    driver: local


### PR DESCRIPTION
This will run an extra container running squeaknode when docker-compose is up.

This squeaknode instance will share the same LND as the squeaknode running on the host, so self-payments won't work.